### PR TITLE
feat: require ext-imagick

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
 		}
 	],
 	"require": {
-		"php": "^8.0"
+		"php": "^8.0",
+		"ext-imagick": "*"
 	},
 	"require-dev": {
 		"phpstan/phpstan": "^1.0",


### PR DESCRIPTION
- bug fix / new feature: no
- BC break: no

Added ext-imagick to composer so if the library is not available, the user will find the issue on installation time, not in runtime.